### PR TITLE
fix(Redis): Remove persistent connection feature from insertMultiple …

### DIFF
--- a/src/Boilerwork/Persistence/Adapters/Redis/RedisTable.php
+++ b/src/Boilerwork/Persistence/Adapters/Redis/RedisTable.php
@@ -119,8 +119,6 @@ final class RedisTable
      */
     public function insertMultiple(iterable $data, bool $overwriteById = false): bool
     {
-        $this->redis->keepConnection();
-
         $result = true;
         foreach ($data as $item) {
             $result = $this->insert($item, $overwriteById);
@@ -128,7 +126,6 @@ final class RedisTable
                 break;
             }
         }
-        $this->redis->releasePersistentConnection();
 
         return $result;
     }


### PR DESCRIPTION
fix(Redis): Remove persistent connection feature from insertMultiple method to avoid problem [FATAL ERROR]: all coroutines (count: 1) are asleep - deadlock!